### PR TITLE
Feature/disk as list

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,6 +39,15 @@ vmware_dns_servers:
 # ------------------------------------------------------------------------------
 vmware_datastore_name:
 vmware_disk_size:
+vmware_disk_list: null
+# ------------------------------------------------------------------------------
+# Example disk list
+# ------------------------------------------------------------------------------
+#
+# vmware_disk_list:
+#   - size_gb: "{{ vmware_disk_size }}"
+#     type: thin
+#     datastore: "{{ vmware_datastore_name }}"
 vmware_vm_folder:
 
 # ------------------------------------------------------------------------------

--- a/tasks/createvm-windows.yml
+++ b/tasks/createvm-windows.yml
@@ -55,7 +55,7 @@
       autologon: "{{ vmware_costumizations_windows_autologon }}"
       password: "{{ vmware_costumizations_windows_template_password }}"
   with_items: "{{ vmware_hosts }}"
-  when: vmware_vcenter_environment == "noproduciton"
+  when: vmware_vcenter_environment == "noproduction"
   register: host_created
 
 - name: creating a VM Windows at vSphere vCenter in Production
@@ -91,7 +91,7 @@
       autologon: "{{ vmware_costumizations_windows_autologon }}"
       password: "{{ vmware_costumizations_windows_template_password }}"
   with_items: "{{ vmware_hosts }}"
-  when: vmware_vcenter_environment == "produciton"
+  when: vmware_vcenter_environment == "production"
   register: host_created
 
 - name: add hosts

--- a/tasks/createvm-windows.yml
+++ b/tasks/createvm-windows.yml
@@ -10,7 +10,7 @@
         datastore: "{{ vmware_datastore_name }}"
   when: 
     - vmware_vcenter_environment == "noproduction"
-    - vmware_disk_list is not none
+    - vmware_disk_list is none
 
 - name: setup Production disk defaults
   set_fact:
@@ -23,7 +23,7 @@
       datastore: "{{ vmware_datastore_name2 }}"
   when: 
     - vmware_vcenter_environment == "production"
-    - vmware_disk_list is not none
+    - vmware_disk_list is none
 
 - name: creating a VM Windows at vSphere vCenter in No-Production
   vmware_guest:

--- a/tasks/createvm-windows.yml
+++ b/tasks/createvm-windows.yml
@@ -10,7 +10,7 @@
         datastore: "{{ vmware_datastore_name }}"
   when: 
     - vmware_vcenter_environment == "noproduction"
-    - vmware_disk_list is not defined
+    - vmware_disk_list is not none
 
 - name: setup Production disk defaults
   set_fact:
@@ -23,7 +23,7 @@
       datastore: "{{ vmware_datastore_name2 }}"
   when: 
     - vmware_vcenter_environment == "production"
-    - vmware_disk_list is not defined
+    - vmware_disk_list is not none
 
 - name: creating a VM Windows at vSphere vCenter in No-Production
   vmware_guest:

--- a/tasks/createvm-windows.yml
+++ b/tasks/createvm-windows.yml
@@ -1,4 +1,30 @@
 ---
+- name: setup No-Production disk defaults
+  set_fact:
+    vmware_disk_list:
+      - size_gb: "{{ vmware_disk_size }}"
+        type: thin
+        datastore: "{{ vmware_datastore_name }}"
+      - size_gb: "{{ vmware_disk_size }}"
+        type: thin
+        datastore: "{{ vmware_datastore_name }}"
+  when: 
+    - vmware_vcenter_environment == "noproduction"
+    - vmware_disk_list is not defined
+
+- name: setup Production disk defaults
+  set_fact:
+    vmware_disk_list:
+    - size_gb: "{{ vmware_disk_size1 }}"
+      type: thin
+      datastore: "{{ vmware_datastore_name1 }}"
+    - size_gb: "{{ vmware_disk_size2 }}"
+      type: thin
+      datastore: "{{ vmware_datastore_name2 }}"
+  when: 
+    - vmware_vcenter_environment == "production"
+    - vmware_disk_list is not defined
+
 - name: creating a VM Windows at vSphere vCenter in No-Production
   vmware_guest:
     hostname: "{{ vmware_vcenter_host }}"
@@ -11,13 +37,7 @@
     guest_id: "{{ vmware_so_guest }}"
     folder: "{{ vmware_vm_folder }}"
     state: poweredon
-    disk:
-    - size_gb: "{{ vmware_disk_size }}"
-      type: thin
-      datastore: "{{ vmware_datastore_name }}"
-    - size_gb: "{{ vmware_disk_size }}"
-      type: thin
-      datastore: "{{ vmware_datastore_name }}"
+    disk: "{{ vmware_disk_list }}"
     hardware:
       memory_mb: "{{ vmware_memory_size }}"
       num_cpus: "{{ vmware_vcpus }}"
@@ -50,13 +70,7 @@
     guest_id: "{{ vmware_so_guest }}"
     folder: "{{ vmware_vm_folder }}"
     state: poweredon
-    disk:
-    - size_gb: "{{ vmware_disk_size1 }}"
-      type: thin
-      datastore: "{{ vmware_datastore_name1 }}"
-    - size_gb: "{{ vmware_disk_size2 }}"
-      type: thin
-      datastore: "{{ vmware_datastore_name2 }}"
+    disk: "{{ vmware_disk_list }}"
     hardware:
       memory_mb: "{{ vmware_memory_size }}"
       num_cpus: "{{ vmware_vcpus }}"


### PR DESCRIPTION
Permite que o usuário defina livremente a lista de discos rígidos da vm através de uma variável lista.
Antigos defaults por ambientes foram preservados para manter retrocompatibilidade.

Ex:
vmware_disk_list:
    - size_gb: "60"
      type: thin
      datastore: "{{ vmware_datastore_name }}"
    - size_gb: "40"
      type: thin
      datastore: "{{ vmware_datastore_name }}"